### PR TITLE
Update local volume name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ newer (or older) versions:
 
  First you will need to set the environment variables required to run Cantaloupe. If you would like to test additional settings, ensure the cantaloupe.propoerties.tmpl template has the variable configured or you have set it as an environment variable.
 
-    docker run -d -p 8182:8182 --name melon -v testimages/:/imageroot cantaloupe
+    docker run -d -p 8182:8182 --name melon -v testimages:/imageroot cantaloupe
 
 will run the container in the background until _docker stop_ is called, looking in specified
 directory for image files.


### PR DESCRIPTION
I think the `testimages/` is just supposed to be an example local volume name but someone might copy and paste what's in the readme and get the error: `"testimages/" includes invalid characters for a local volume name`

It would be less confusing for the new user to just use `testimages` as the example local volume name.