### PR TITLE
Docker packaging updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# See https://editorconfig.org for format details and
+# https://editorconfig.org/#download for editor / IDE integration
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-#ENV IMAGEMAGICK_VERSION=7.0.8-14
 FROM debian:buster
 
 EXPOSE 8182
@@ -14,18 +13,6 @@ RUN apt-get update -qy && apt-get dist-upgrade -qy && \
 RUN adduser --system cantaloupe
 
 WORKDIR /tmp
-
-#ImageMagick 7 install - re-evaluate once officially deprecated
-#RUN cd /tools && \
-#    wget http://imagemagick.org/download/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz && \
-#    tar -xf ImageMagick-$IMAGEMAGICK_VERSION.tar.xz && \
-#    cd ImageMagick-$IMAGEMAGICK_VERSION && \
-#    ./configure --prefix /usr/local && \
-#    make && \
-#    make install && \
-#    cd .. && \
-#    ldconfig /usr/local/lib && \
-#    rm -rf  ImageMagick*
 
 ARG CANTALOUPE_VERSION=4.1.1
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:11-slim
 #ENV IMAGEMAGICK_VERSION=7.0.8-14
+FROM debian:buster
 
 EXPOSE 8182
 
@@ -7,7 +7,7 @@ VOLUME /imageroot
 
 # Update packages and install tools
 RUN apt-get update -qy && apt-get dist-upgrade -qy && \
-   apt-get install -qy --no-install-recommends graphicsmagick curl imagemagick libopenjp2-tools ffmpeg gettext unzip && \
+   apt-get install -qy --no-install-recommends curl imagemagick libopenjp2-tools ffmpeg gettext unzip default-jre-headless && \
    apt-get -qqy autoremove && apt-get -qqy autoclean
 
 # Run non privileged

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ VOLUME /imageroot
 
 # Update packages and install tools
 RUN apt-get update -qy && apt-get dist-upgrade -qy && \
-   apt-get install -qy --no-install-recommends curl imagemagick libopenjp2-tools ffmpeg gettext unzip default-jre-headless && \
-   apt-get -qqy autoremove && apt-get -qqy autoclean
+    apt-get install -qy --no-install-recommends curl imagemagick libopenjp2-tools ffmpeg gettext unzip default-jre-headless && \
+    apt-get -qqy autoremove && apt-get -qqy autoclean
 
 # Run non privileged
 RUN adduser --system cantaloupe
@@ -18,22 +18,22 @@ ARG CANTALOUPE_VERSION=4.1.2
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
 # Get and unpack Cantaloupe release archive
- && mkdir -p /usr/local/ \
- && cd /usr/local \
- && unzip /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
- && ln -s cantaloupe-$CANTALOUPE_VERSION cantaloupe \
- && rm -rf /tmp/Cantaloupe-$CANTALOUPE_VERSION \
- && rm /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip
 RUN curl --silent --fail -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip \
+    && mkdir -p /usr/local/ \
+    && cd /usr/local \
+    && unzip /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
+    && ln -s cantaloupe-$CANTALOUPE_VERSION cantaloupe \
+    && rm -rf /tmp/Cantaloupe-$CANTALOUPE_VERSION \
+    && rm /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip
 
 COPY entrypoint.sh /usr/local/bin/
 COPY cantaloupe.properties.tmpl /etc/cantaloupe.properties.tmpl
 RUN mkdir -p /var/log/cantaloupe /var/cache/cantaloupe \
- && touch /etc/cantaloupe.properties \
- && chown -R cantaloupe /var/log/cantaloupe /var/cache/cantaloupe \
+    && touch /etc/cantaloupe.properties \
+    && chown -R cantaloupe /var/log/cantaloupe /var/cache/cantaloupe \
     /etc/cantaloupe.properties /usr/local/bin/entrypoint.sh \
- && cp /usr/local/cantaloupe/deps/Linux-x86-64/lib/* /usr/lib/ \
- && cp /usr/local/cantaloupe/deps/Linux-x86-64/bin/* /usr/bin/
+    && cp /usr/local/cantaloupe/deps/Linux-x86-64/lib/* /usr/lib/ \
+    && cp /usr/local/cantaloupe/deps/Linux-x86-64/bin/* /usr/bin/
 
 
 USER cantaloupe

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,13 @@ ARG CANTALOUPE_VERSION=4.1.1
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
 # Get and unpack Cantaloupe release archive
-RUN curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip \
  && mkdir -p /usr/local/ \
  && cd /usr/local \
  && unzip /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
  && ln -s cantaloupe-$CANTALOUPE_VERSION cantaloupe \
  && rm -rf /tmp/Cantaloupe-$CANTALOUPE_VERSION \
  && rm /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip
+RUN curl --silent --fail -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip \
 
 COPY entrypoint.sh /usr/local/bin/
 COPY cantaloupe.properties.tmpl /etc/cantaloupe.properties.tmpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN adduser --system cantaloupe
 
 WORKDIR /tmp
 
-ARG CANTALOUPE_VERSION=4.1.1
+ARG CANTALOUPE_VERSION=4.1.2
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
 # Get and unpack Cantaloupe release archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ EXPOSE 8182
 VOLUME /imageroot
 
 # Update packages and install tools
-RUN apt-get update -y && \
-   apt-get install -y --no-install-recommends graphicsmagick curl imagemagick libopenjp2-tools ffmpeg gettext unzip && \
-   rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qy && apt-get dist-upgrade -qy && \
+   apt-get install -qy --no-install-recommends graphicsmagick curl imagemagick libopenjp2-tools ffmpeg gettext unzip && \
+   apt-get -qqy autoremove && apt-get -qqy autoclean
 
 # Run non privileged
 RUN adduser --system cantaloupe

--- a/cantaloupe.properties.default
+++ b/cantaloupe.properties.default
@@ -89,7 +89,7 @@ endpoint.iiif.2.enabled = true
 # Controls the response Content-Disposition header for images. Allowed
 # values are `inline`, `attachment`, and `none`. This can be overridden
 # using the ?response-content-disposition query argument.
-endpoint.iiif.content_disposition = inline
+endpoint.iiif.content_disposition = none
 
 # Minimum size that will be used in info.json `sizes` keys.
 endpoint.iiif.min_size = 64

--- a/cantaloupe.properties.tmpl
+++ b/cantaloupe.properties.tmpl
@@ -417,7 +417,7 @@ cache.server.derivative.ttl_seconds = 0
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either
 # independently or in front of a "level 2" derivative cache (if enabled).
-cache.server.info.enabled = false
+cache.server.info.enabled = true
 
 # If true, when a source reports that the requested source image has gone
 # missing, all cached information relating to it (if any) will be deleted.

--- a/cantaloupe.properties.tmpl
+++ b/cantaloupe.properties.tmpl
@@ -81,7 +81,7 @@ endpoint.iiif.2.enabled = true
 # Controls the response Content-Disposition header for images. Allowed
 # values are `inline`, `attachment`, and `none`. This can be overridden
 # using the ?response-content-disposition query argument.
-endpoint.iiif.content_disposition = inline
+endpoint.iiif.content_disposition = none
 
 # Minimum size that will be used in info.json `sizes` keys.
 endpoint.iiif.min_size = 64

--- a/cantaloupe.properties.tmpl
+++ b/cantaloupe.properties.tmpl
@@ -423,7 +423,7 @@ cache.server.info.enabled = true
 # missing, all cached information relating to it (if any) will be deleted.
 # (This is effectively always false when cache.server.resolve_first is also
 # false.)
-cache.server.purge_missing = false
+cache.server.purge_missing = true
 
 # If true, the source image will be confirmed to exist before a cached copy
 # is returned. If false, the cached copy will be returned without checking.
@@ -432,7 +432,7 @@ cache.server.resolve_first = false
 
 # !! Enables the cache worker, which periodically purges invalid cache
 # items in the background.
-cache.server.worker.enabled = false
+cache.server.worker.enabled = true
 
 # !! The cache worker will wait this many seconds before starting its
 # next shift.


### PR DESCRIPTION
I made a few other changes in the process of setting up a test cluster. Major points:

* APT updates are always installed to ensure that any pending security updates are present
* Switch to Debian Buster as the base image to get a newer version of OpenJPEG (2.3 vs. 2.1) — this was necessary to get it to load bitonal JP2s at all and also avoids a console warning on startup about opj_decompress. https://github.com/uclouvain/openjpeg/blob/master/CHANGELOG.md suggests that this should bring some performance & memory usage improvements but I haven't measured this.